### PR TITLE
Added support for extra link styles and added HAL-like example class

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,36 @@ class ItemSummary(HyperModel):
 
 </td>
 </tr>
+<tr>
+<td>
+
+```python
+class ItemSummary(HyperModel):
+    name: str
+    id: str
+    link = HALFor(
+        "read_item", {"item_id": "<id>"}, 
+        description="Read a specific item"
+    )
+```
+
+</td>
+<td>
+
+```json
+{
+  "name": "Foo",
+  "id": "item01",
+  "link": {
+      "href": "/items/item01",
+      "method": "GET",
+      "description": "Read a specific item"
+  }
+}
+```
+
+</td>
+</tr>
 </tbody>
 </table>
 

--- a/fastapi_hypermodel/hypermodel.py
+++ b/fastapi_hypermodel/hypermodel.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, root_validator, PrivateAttr
 from pydantic.utils import update_not_none
 from pydantic.validators import dict_validator
 from starlette.datastructures import URLPath
+from starlette.routing import Route
 
 _tpl_pattern = re.compile(r"\s*<\s*(\S*)\s*>\s*")
 
@@ -105,7 +106,12 @@ class HALFor(HALItem, AbstractHyperField):
         resolved_params = _resolve_param_values(self._param_values, values)
 
         this_route = next(
-            (route for route in app.routes if route.name == self._endpoint), None
+            (
+                route
+                for route in app.routes
+                if isinstance(route, Route) and route.name == self._endpoint
+            ),
+            None,
         )
         if not this_route:
             raise ValueError(f"No route found for endpoint {self._endpoint}")

--- a/fastapi_hypermodel/hypermodel.py
+++ b/fastapi_hypermodel/hypermodel.py
@@ -69,7 +69,7 @@ class UrlFor(str, AbstractHyperField):
 
     def __build_hypermedia__(
         self, app: Optional[FastAPI], values: Dict[str, Any]
-    ) -> str:
+    ) -> Optional[str]:
         if app is None:
             return None
         resolved_params = _resolve_param_values(self.param_values, values)
@@ -90,8 +90,8 @@ class LinkSet(_LinkSetType, AbstractHyperField):  # pylint: disable=too-many-anc
 
     def __build_hypermedia__(
         self, app: Optional[FastAPI], values: Dict[str, Any]
-    ) -> str:
-        return {k: u.__build_hypermedia__(app, values) for k, u in self.items()}
+    ) -> Dict[str, str]:
+        return {k: u.__build_hypermedia__(app, values) for k, u in self.items()}  # type: ignore
 
 
 def _tpl(val):

--- a/fastapi_hypermodel/hypermodel.py
+++ b/fastapi_hypermodel/hypermodel.py
@@ -77,7 +77,7 @@ class UrlFor(UrlType, AbstractHyperField):
 
 class HALItem(BaseModel):
     href: Optional[UrlType]
-    methods: Optional[List[str]]
+    method: Optional[str]
     description: Optional[str]
 
 
@@ -112,7 +112,7 @@ class HALFor(HALItem, AbstractHyperField):
 
         return HALItem(
             href=app.url_path_for(self._endpoint, **resolved_params),
-            methods=this_route.methods or None,
+            method=this_route.methods.pop() if this_route.methods else None,
             description=self._description,
         )
 

--- a/fastapi_hypermodel/hypermodel.py
+++ b/fastapi_hypermodel/hypermodel.py
@@ -138,7 +138,7 @@ class LinkSet(_LinkSetType, AbstractHyperField):  # pylint: disable=too-many-anc
     def __build_hypermedia__(
         self, app: Optional[FastAPI], values: Dict[str, Any]
     ) -> Dict[str, str]:
-        return {k: u.__build_hypermedia__(app, values) for k, u in self.items()}  # type: ignore
+        return {k: u.__build_hypermedia__(app, values) for k, u in self.items()}  # type: ignore  # pylint: disable=no-member
 
 
 def _tpl(val):

--- a/fastapi_hypermodel/hypermodel.py
+++ b/fastapi_hypermodel/hypermodel.py
@@ -75,24 +75,6 @@ class UrlFor(UrlType, AbstractHyperField):
         return app.url_path_for(self.endpoint, **resolved_params)
 
 
-_LinkSetType = Dict[str, UrlFor]
-
-
-class LinkSet(_LinkSetType, AbstractHyperField):  # pylint: disable=too-many-ancestors
-    @classmethod
-    def __get_validators__(cls):
-        yield dict_validator
-
-    @classmethod
-    def __modify_schema__(cls, field_schema: Dict[str, Any]) -> None:
-        field_schema.update({"additionalProperties": _uri_schema})
-
-    def __build_hypermedia__(
-        self, app: Optional[FastAPI], values: Dict[str, Any]
-    ) -> Dict[str, str]:
-        return {k: u.__build_hypermedia__(app, values) for k, u in self.items()}  # type: ignore
-
-
 class HALItem(BaseModel):
     href: Optional[UrlType]
     methods: Optional[List[str]]
@@ -133,6 +115,24 @@ class HALFor(HALItem, AbstractHyperField):
             methods=this_route.methods or None,
             description=self._description,
         )
+
+
+_LinkSetType = Dict[str, UrlFor]
+
+
+class LinkSet(_LinkSetType, AbstractHyperField):  # pylint: disable=too-many-ancestors
+    @classmethod
+    def __get_validators__(cls):
+        yield dict_validator
+
+    @classmethod
+    def __modify_schema__(cls, field_schema: Dict[str, Any]) -> None:
+        field_schema.update({"additionalProperties": _uri_schema})
+
+    def __build_hypermedia__(
+        self, app: Optional[FastAPI], values: Dict[str, Any]
+    ) -> Dict[str, str]:
+        return {k: u.__build_hypermedia__(app, values) for k, u in self.items()}  # type: ignore
 
 
 def _tpl(val):

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,4 +1,23 @@
 [[package]]
+name = "anyio"
+version = "3.3.4"
+description = "High level compatibility layer for multiple asynchronous event loop implementations"
+category = "main"
+optional = false
+python-versions = ">=3.6.2"
+
+[package.dependencies]
+dataclasses = {version = "*", markers = "python_version < \"3.7\""}
+idna = ">=2.8"
+sniffio = ">=1.1"
+typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
+
+[package.extras]
+doc = ["sphinx-rtd-theme", "sphinx-autodoc-typehints (>=1.2.0)"]
+test = ["coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "pytest (>=6.0)", "pytest-mock (>=3.6.1)", "trustme", "uvloop (<0.15)", "mock (>=4)", "uvloop (>=0.15)"]
+trio = ["trio (>=0.16)"]
+
+[[package]]
 name = "astroid"
 version = "2.8.5"
 description = "An abstract syntax tree for Python with inference support."
@@ -128,6 +147,25 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "contextlib2"
+version = "21.6.0"
+description = "Backports and enhancements for the contextlib module"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "contextvars"
+version = "2.4"
+description = "PEP 567 Backport"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+immutables = ">=0.9"
+
+[[package]]
 name = "coverage"
 version = "6.1.2"
 description = "Code coverage measurement for Python"
@@ -156,7 +194,7 @@ python-versions = "*"
 
 [[package]]
 name = "fastapi"
-version = "0.68.2"
+version = "0.70.0"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
 category = "main"
 optional = false
@@ -164,13 +202,13 @@ python-versions = ">=3.6.1"
 
 [package.dependencies]
 pydantic = ">=1.6.2,<1.7 || >1.7,<1.7.1 || >1.7.1,<1.7.2 || >1.7.2,<1.7.3 || >1.7.3,<1.8 || >1.8,<1.8.1 || >1.8.1,<2.0.0"
-starlette = "0.14.2"
+starlette = "0.16.0"
 
 [package.extras]
-all = ["requests (>=2.24.0,<3.0.0)", "aiofiles (>=0.5.0,<0.8.0)", "jinja2 (>=2.11.2,<3.0.0)", "python-multipart (>=0.0.5,<0.0.6)", "itsdangerous (>=1.1.0,<2.0.0)", "pyyaml (>=5.3.1,<6.0.0)", "graphene (>=2.1.8,<3.0.0)", "ujson (>=4.0.1,<5.0.0)", "orjson (>=3.2.1,<4.0.0)", "email_validator (>=1.1.1,<2.0.0)", "uvicorn[standard] (>=0.12.0,<0.16.0)", "async_exit_stack (>=1.0.1,<2.0.0)", "async_generator (>=1.10,<2.0.0)"]
-dev = ["python-jose[cryptography] (>=3.3.0,<4.0.0)", "passlib[bcrypt] (>=1.7.2,<2.0.0)", "autoflake (>=1.4.0,<2.0.0)", "flake8 (>=3.8.3,<4.0.0)", "uvicorn[standard] (>=0.12.0,<0.16.0)", "graphene (>=2.1.8,<3.0.0)"]
+all = ["requests (>=2.24.0,<3.0.0)", "jinja2 (>=2.11.2,<4.0.0)", "python-multipart (>=0.0.5,<0.0.6)", "itsdangerous (>=1.1.0,<3.0.0)", "pyyaml (>=5.3.1,<6.0.0)", "ujson (>=4.0.1,<5.0.0)", "orjson (>=3.2.1,<4.0.0)", "email_validator (>=1.1.1,<2.0.0)", "uvicorn[standard] (>=0.12.0,<0.16.0)"]
+dev = ["python-jose[cryptography] (>=3.3.0,<4.0.0)", "passlib[bcrypt] (>=1.7.2,<2.0.0)", "autoflake (>=1.4.0,<2.0.0)", "flake8 (>=3.8.3,<4.0.0)", "uvicorn[standard] (>=0.12.0,<0.16.0)"]
 doc = ["mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=7.1.9,<8.0.0)", "mdx-include (>=1.4.1,<2.0.0)", "mkdocs-markdownextradata-plugin (>=0.1.7,<0.3.0)", "typer-cli (>=0.0.12,<0.0.13)", "pyyaml (>=5.3.1,<6.0.0)"]
-test = ["pytest (>=6.2.4,<7.0.0)", "pytest-cov (>=2.12.0,<4.0.0)", "pytest-asyncio (>=0.14.0,<0.16.0)", "mypy (==0.910)", "flake8 (>=3.8.3,<4.0.0)", "black (==21.9b0)", "isort (>=5.0.6,<6.0.0)", "requests (>=2.24.0,<3.0.0)", "httpx (>=0.14.0,<0.19.0)", "email_validator (>=1.1.1,<2.0.0)", "sqlalchemy (>=1.3.18,<1.5.0)", "peewee (>=3.13.3,<4.0.0)", "databases[sqlite] (>=0.3.2,<0.6.0)", "orjson (>=3.2.1,<4.0.0)", "ujson (>=4.0.1,<5.0.0)", "python-multipart (>=0.0.5,<0.0.6)", "aiofiles (>=0.5.0,<0.8.0)", "flask (>=1.1.2,<2.0.0)", "async_exit_stack (>=1.0.1,<2.0.0)", "async_generator (>=1.10,<2.0.0)", "types-ujson (==0.1.1)", "types-orjson (==3.6.0)", "types-dataclasses (==0.1.7)"]
+test = ["pytest (>=6.2.4,<7.0.0)", "pytest-cov (>=2.12.0,<4.0.0)", "mypy (==0.910)", "flake8 (>=3.8.3,<4.0.0)", "black (==21.9b0)", "isort (>=5.0.6,<6.0.0)", "requests (>=2.24.0,<3.0.0)", "httpx (>=0.14.0,<0.19.0)", "email_validator (>=1.1.1,<2.0.0)", "sqlalchemy (>=1.3.18,<1.5.0)", "peewee (>=3.13.3,<4.0.0)", "databases[sqlite] (>=0.3.2,<0.6.0)", "orjson (>=3.2.1,<4.0.0)", "ujson (>=4.0.1,<5.0.0)", "python-multipart (>=0.0.5,<0.0.6)", "flask (>=1.1.2,<3.0.0)", "anyio[trio] (>=3.2.1,<4.0.0)", "types-ujson (==0.1.1)", "types-orjson (==3.6.0)", "types-dataclasses (==0.1.7)"]
 
 [[package]]
 name = "filelock"
@@ -219,9 +257,23 @@ python-versions = ">=3.6"
 name = "idna"
 version = "3.3"
 description = "Internationalized Domain Names in Applications (IDNA)"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.5"
+
+[[package]]
+name = "immutables"
+version = "0.16"
+description = "Immutable Collections"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+typing-extensions = {version = ">=3.7.4.3", markers = "python_version < \"3.8\""}
+
+[package.extras]
+test = ["flake8 (>=3.8.4,<3.9.0)", "pycodestyle (>=2.6.0,<2.7.0)", "mypy (>=0.910)", "pytest (>=6.2.4,<6.3.0)"]
 
 [[package]]
 name = "importlib-metadata"
@@ -509,15 +561,31 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "sniffio"
+version = "1.2.0"
+description = "Sniff out which async library your code is running under"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+contextvars = {version = ">=2.1", markers = "python_version < \"3.7\""}
+
+[[package]]
 name = "starlette"
-version = "0.14.2"
+version = "0.16.0"
 description = "The little ASGI library that shines."
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
+[package.dependencies]
+anyio = ">=3.0.0,<4"
+contextlib2 = {version = ">=21.6.0", markers = "python_version < \"3.7\""}
+typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
+
 [package.extras]
-full = ["aiofiles", "graphene", "itsdangerous", "jinja2", "python-multipart", "pyyaml", "requests"]
+full = ["itsdangerous", "jinja2", "python-multipart", "pyyaml", "requests", "graphene"]
 
 [[package]]
 name = "stevedore"
@@ -670,6 +738,10 @@ python-versions = ">=3.6.2,<4.0"
 content-hash = "42218066aae19ea8751cb66cbb4e14082501664ff4f9d3146d3474d71250ba10"
 
 [metadata.files]
+anyio = [
+    {file = "anyio-3.3.4-py3-none-any.whl", hash = "sha256:4fd09a25ab7fa01d34512b7249e366cd10358cdafc95022c7ff8c8f8a5026d66"},
+    {file = "anyio-3.3.4.tar.gz", hash = "sha256:67da67b5b21f96b9d3d65daa6ea99f5d5282cb09f50eb4456f8fb51dffefc3ff"},
+]
 astroid = [
     {file = "astroid-2.8.5-py3-none-any.whl", hash = "sha256:abc423a1e85bc1553954a14f2053473d2b7f8baf32eae62a328be24f436b5107"},
     {file = "astroid-2.8.5.tar.gz", hash = "sha256:11f7356737b624c42e21e71fe85eea6875cb94c03c82ac76bd535a0ff10b0f25"},
@@ -709,6 +781,13 @@ click = [
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
+]
+contextlib2 = [
+    {file = "contextlib2-21.6.0-py2.py3-none-any.whl", hash = "sha256:3fbdb64466afd23abaf6c977627b75b6139a5a3e8ce38405c5b413aed7a0471f"},
+    {file = "contextlib2-21.6.0.tar.gz", hash = "sha256:ab1e2bfe1d01d968e1b7e8d9023bc51ef3509bba217bb730cee3827e1ee82869"},
+]
+contextvars = [
+    {file = "contextvars-2.4.tar.gz", hash = "sha256:f38c908aaa59c14335eeea12abea5f443646216c4e29380d7bf34d2018e2c39e"},
 ]
 coverage = [
     {file = "coverage-6.1.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:675adb3b3380967806b3cbb9c5b00ceb29b1c472692100a338730c1d3e59c8b9"},
@@ -768,8 +847,8 @@ distlib = [
     {file = "distlib-0.3.3.zip", hash = "sha256:d982d0751ff6eaaab5e2ec8e691d949ee80eddf01a62eaa96ddb11531fe16b05"},
 ]
 fastapi = [
-    {file = "fastapi-0.68.2-py3-none-any.whl", hash = "sha256:36bcdd3dbea87c586061005e4a40b9bd0145afd766655b4e0ec1d8870b32555c"},
-    {file = "fastapi-0.68.2.tar.gz", hash = "sha256:38526fc46bda73f7ec92033952677323c16061e70a91d15c95f18b11895da494"},
+    {file = "fastapi-0.70.0-py3-none-any.whl", hash = "sha256:a36d5f2fad931aa3575c07a3472c784e81f3e664e3bb5c8b9c88d0ec1104f59c"},
+    {file = "fastapi-0.70.0.tar.gz", hash = "sha256:66da43cfe5185ea1df99552acffd201f1832c6b364e0f4136c0a99f933466ced"},
 ]
 filelock = [
     {file = "filelock-3.3.2-py3-none-any.whl", hash = "sha256:bb2a1c717df74c48a2d00ed625e5a66f8572a3a30baacb7657add1d7bac4097b"},
@@ -790,6 +869,35 @@ h11 = [
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
     {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
+]
+immutables = [
+    {file = "immutables-0.16-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:acbfa79d44228d96296279068441f980dc63dbed52522d9227ff9f4d96c6627e"},
+    {file = "immutables-0.16-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c9ed003eacb92e630ef200e31f47236c2139b39476894f7963b32bd39bafa3"},
+    {file = "immutables-0.16-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0a396314b9024fa55bf83a27813fd76cf9f27dce51f53b0f19b51de035146251"},
+    {file = "immutables-0.16-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:4a2a71678348fb95b13ca108d447f559a754c41b47bd1e7e4fb23974e735682d"},
+    {file = "immutables-0.16-cp36-cp36m-win32.whl", hash = "sha256:064001638ab5d36f6aa05b6101446f4a5793fb71e522bc81b8fc65a1894266ff"},
+    {file = "immutables-0.16-cp36-cp36m-win_amd64.whl", hash = "sha256:1de393f1b188740ca7b38f946f2bbc7edf3910d2048f03bbb8d01f17a038d67c"},
+    {file = "immutables-0.16-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:fcf678a3074613119385a02a07c469ec5130559f5ea843c85a0840c80b5b71c6"},
+    {file = "immutables-0.16-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a307eb0984eb43e815dcacea3ac50c11d00a936ecf694c46991cd5a23bcb0ec0"},
+    {file = "immutables-0.16-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7a58825ff2254e2612c5a932174398a4ea8fbddd8a64a02c880cc32ee28b8820"},
+    {file = "immutables-0.16-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:798b095381eb42cf40db6876339e7bed84093e5868018a9e73d8e1f7ab4bb21e"},
+    {file = "immutables-0.16-cp37-cp37m-win32.whl", hash = "sha256:19bdede174847c2ef1292df0f23868ab3918b560febb09fcac6eec621bd4812b"},
+    {file = "immutables-0.16-cp37-cp37m-win_amd64.whl", hash = "sha256:9ccf4c0e3e2e3237012b516c74c49de8872ccdf9129739f7a0b9d7444a8c4862"},
+    {file = "immutables-0.16-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:d59beef203a3765db72b1d0943547425c8318ecf7d64c451fd1e130b653c2fbb"},
+    {file = "immutables-0.16-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0020aaa4010b136056c20a46ce53204e1407a9e4464246cb2cf95b90808d9161"},
+    {file = "immutables-0.16-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:edd9f67671555af1eb99ad3c7550238487dd7ac0ac5205b40204ed61c9a922ac"},
+    {file = "immutables-0.16-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:298a301f85f307b4c056a0825eb30f060e64d73605e783289f3df37dd762bab8"},
+    {file = "immutables-0.16-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:b779617f5b94486bfd0f22162cd72eb5f2beb0214a14b75fdafb7b2c908ed0cb"},
+    {file = "immutables-0.16-cp38-cp38-win32.whl", hash = "sha256:511c93d8b1bbbf103ff3f1f120c5a68a9866ce03dea6ac406537f93ca9b19139"},
+    {file = "immutables-0.16-cp38-cp38-win_amd64.whl", hash = "sha256:b651b61c1af6cda2ee201450f2ffe048a5959bc88e43e6c312f4c93e69c9e929"},
+    {file = "immutables-0.16-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:aa7bf572ae1e006104c584be70dc634849cf0dc62f42f4ee194774f97e7fd17d"},
+    {file = "immutables-0.16-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:50793a44ba0d228ed8cad4d0925e00dfd62ea32f44ddee8854f8066447272d05"},
+    {file = "immutables-0.16-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:799621dcdcdcbb2516546a40123b87bf88de75fe7459f7bd8144f079ace6ec3e"},
+    {file = "immutables-0.16-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7bcf52aeb983bd803b7c6106eae1b2d9a0c7ab1241bc6b45e2174ba2b7283031"},
+    {file = "immutables-0.16-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:734c269e82e5f307fb6e17945953b67659d1731e65309787b8f7ba267d1468f2"},
+    {file = "immutables-0.16-cp39-cp39-win32.whl", hash = "sha256:a454d5d3fee4b7cc627345791eb2ca4b27fa3bbb062ccf362ecaaa51679a07ed"},
+    {file = "immutables-0.16-cp39-cp39-win_amd64.whl", hash = "sha256:2505d93395d3f8ae4223e21465994c3bc6952015a38dc4f03cb3e07a2b8d8325"},
+    {file = "immutables-0.16.tar.gz", hash = "sha256:d67e86859598eed0d926562da33325dac7767b7b1eff84e232c22abea19f4360"},
 ]
 importlib-metadata = [
     {file = "importlib_metadata-4.8.2-py3-none-any.whl", hash = "sha256:53ccfd5c134223e497627b9815d5030edf77d2ed573922f7a0b8f8bb81a1c100"},
@@ -1025,9 +1133,13 @@ smmap = [
     {file = "smmap-5.0.0-py3-none-any.whl", hash = "sha256:2aba19d6a040e78d8b09de5c57e96207b09ed71d8e55ce0959eeee6c8e190d94"},
     {file = "smmap-5.0.0.tar.gz", hash = "sha256:c840e62059cd3be204b0c9c9f74be2c09d5648eddd4580d9314c3ecde0b30936"},
 ]
+sniffio = [
+    {file = "sniffio-1.2.0-py3-none-any.whl", hash = "sha256:471b71698eac1c2112a40ce2752bb2f4a4814c22a54a3eed3676bc0f5ca9f663"},
+    {file = "sniffio-1.2.0.tar.gz", hash = "sha256:c4666eecec1d3f50960c6bdf61ab7bc350648da6c126e3cf6898d8cd4ddcd3de"},
+]
 starlette = [
-    {file = "starlette-0.14.2-py3-none-any.whl", hash = "sha256:3c8e48e52736b3161e34c9f0e8153b4f32ec5d8995a3ee1d59410d92f75162ed"},
-    {file = "starlette-0.14.2.tar.gz", hash = "sha256:7d49f4a27f8742262ef1470608c59ddbc66baf37c148e938c7038e6bc7a998aa"},
+    {file = "starlette-0.16.0-py3-none-any.whl", hash = "sha256:38eb24bf705a2c317e15868e384c1b8a12ca396e5a3c3a003db7e667c43f939f"},
+    {file = "starlette-0.16.0.tar.gz", hash = "sha256:e1904b5d0007aee24bdd3c43994be9b3b729f4f58e740200de1d623f8c3a8870"},
 ]
 stevedore = [
     {file = "stevedore-3.5.0-py3-none-any.whl", hash = "sha256:a547de73308fd7e90075bb4d301405bebf705292fa90a90fc3bcf9133f58616c"},

--- a/tests/app.py
+++ b/tests/app.py
@@ -1,6 +1,7 @@
 from typing import List, Optional
 
 from fastapi import FastAPI
+from pydantic.main import BaseModel
 
 from fastapi_hypermodel import HyperModel, UrlFor, LinkSet
 
@@ -15,6 +16,12 @@ class ItemSummary(HyperModel):
 class ItemDetail(ItemSummary):
     description: Optional[str] = None
     price: float
+
+
+class ItemUpdate(BaseModel):
+    name: Optional[str]
+    description: Optional[str]
+    price: Optional[float]
 
 
 class Person(HyperModel):
@@ -70,6 +77,11 @@ def create_app():
 
     @app.get("/items/{item_id}", response_model=ItemDetail)
     def read_item(item_id: str):
+        return items[item_id]
+
+    @app.put("/items/{item_id}", response_model=ItemDetail)
+    def update_item(item_id: str, item: ItemUpdate):
+        items[item_id].update(item.dict(exclude_none=True))
         return items[item_id]
 
     @app.get(

--- a/tests/app.py
+++ b/tests/app.py
@@ -47,6 +47,11 @@ class Person(HyperModel):
         {
             "self": HALFor("read_person", {"person_id": "<id>"}),
             "items": HALFor("read_person_items", {"person_id": "<id>"}),
+            "addItem": HALFor(
+                "put_person_items",
+                {"person_id": "<id>"},
+                description="Add an item to this person and the items list",
+            ),
         }
     )
 

--- a/tests/test_fastapi_hypermodel.py
+++ b/tests/test_fastapi_hypermodel.py
@@ -96,7 +96,7 @@ def test_people_hal(client, person_id):
     response = client.get(url)
     assert "hal_href" in response.json()
     assert response.json().get("hal_href").get("href") == url
-    assert response.json().get("hal_href").get("methods") == ["GET"]
+    assert response.json().get("hal_href").get("method") == "GET"
 
 
 @pytest.mark.parametrize("person_id", people.keys())

--- a/tests/test_fastapi_hypermodel.py
+++ b/tests/test_fastapi_hypermodel.py
@@ -104,15 +104,16 @@ def test_people_halset(client, person_id):
     url = f"/people/{person_id}"
     response = client.get(url)
     assert "href" in response.json()
-    print(response.json().get("_links"))
+    links = response.json().get("_links")
 
+    assert "items" in links
+    assert links["items"]["href"] == url + "/items"
+    assert links["items"]["methods"] == ["GET"]
 
-# @pytest.mark.parametrize("person_id", people.keys())
-# def test_people_halset(client, person_id):
-#    url = f"/people/{person_id}"
-#    response = client.get(url)
-#    assert "href" in response.json()
-#    print(response.json().get("_links"))
+    assert "addItem" in links
+    assert links["addItem"]["href"] == url + "/items"
+    assert links["addItem"]["methods"] == ["PUT"]
+    assert links["addItem"]["description"]
 
 
 def test_bad_attribute(app):

--- a/tests/test_fastapi_hypermodel.py
+++ b/tests/test_fastapi_hypermodel.py
@@ -108,11 +108,11 @@ def test_people_halset(client, person_id):
 
     assert "items" in links
     assert links["items"]["href"] == url + "/items"
-    assert links["items"]["methods"] == ["GET"]
+    assert links["items"]["method"] == "GET"
 
     assert "addItem" in links
     assert links["addItem"]["href"] == url + "/items"
-    assert links["addItem"]["methods"] == ["PUT"]
+    assert links["addItem"]["method"] == "PUT"
     assert links["addItem"]["description"]
 
 

--- a/tests/test_fastapi_hypermodel.py
+++ b/tests/test_fastapi_hypermodel.py
@@ -98,3 +98,10 @@ def test_bad_attribute(app):
 
     with pytest.raises(InvalidAttribute):
         _ = ItemSummary()
+
+
+def test_update_item(client):
+    url = "/items/item01"
+    response = client.put(url, json={"name": "updated"})
+    assert "href" in response.json()
+    assert response.json().get("href") == url

--- a/tests/test_fastapi_hypermodel.py
+++ b/tests/test_fastapi_hypermodel.py
@@ -90,6 +90,31 @@ def test_people_linkset(client, person_id):
     }
 
 
+@pytest.mark.parametrize("person_id", people.keys())
+def test_people_hal(client, person_id):
+    url = f"/people/{person_id}"
+    response = client.get(url)
+    assert "hal_href" in response.json()
+    assert response.json().get("hal_href").get("href") == url
+    assert response.json().get("hal_href").get("methods") == ["GET"]
+
+
+@pytest.mark.parametrize("person_id", people.keys())
+def test_people_halset(client, person_id):
+    url = f"/people/{person_id}"
+    response = client.get(url)
+    assert "href" in response.json()
+    print(response.json().get("_links"))
+
+
+# @pytest.mark.parametrize("person_id", people.keys())
+# def test_people_halset(client, person_id):
+#    url = f"/people/{person_id}"
+#    response = client.get(url)
+#    assert "href" in response.json()
+#    print(response.json().get("_links"))
+
+
 def test_bad_attribute(app):
     class ItemSummary(HyperModel):
         href = UrlFor("read_item", {"item_id": "<id>"})
@@ -100,8 +125,18 @@ def test_bad_attribute(app):
         _ = ItemSummary()
 
 
+### APP TESTS, SHOULD REMOVE
+
+
 def test_update_item(client):
     url = "/items/item01"
     response = client.put(url, json={"name": "updated"})
     assert "href" in response.json()
     assert response.json().get("href") == url
+
+
+@pytest.mark.parametrize("person_id", people.keys())
+def test_create_item(client, person_id):
+    url = f"/people/{person_id}/items"
+    response = client.put(url, json={"id": "item04", "name": "Qux", "price": 20.2})
+    assert "item04" in [item.get("id") for item in response.json()]

--- a/tests/test_fastapi_hypermodel_schemas.py
+++ b/tests/test_fastapi_hypermodel_schemas.py
@@ -1,0 +1,18 @@
+from fastapi_hypermodel.hypermodel import _uri_schema
+
+
+def _is_subset(d1: dict, d2: dict):
+    return all(d1.get(k) == d2.get(k) for k in d2)
+
+
+def test_openapi_schema_href(app):
+    openapi = app.openapi()
+    href_schema = openapi["components"]["schemas"]["Person"]["properties"]["href"]
+    assert _is_subset(href_schema, _uri_schema)
+
+
+def test_openapi_schema_linkset(app):
+    openapi = app.openapi()
+    linkset_schema = openapi["components"]["schemas"]["Person"]["properties"]["links"]
+    assert linkset_schema["type"] == "object"
+    assert _is_subset(linkset_schema["additionalProperties"], _uri_schema)


### PR DESCRIPTION
<table>
<tbody>
<tr>
<th>Model</th>
<th>Response</th>
</tr>
<tr>
<td>

```python
class ItemSummary(HyperModel):
    name: str
    id: str
    link = HALFor(
        "read_item", {"item_id": "<id>"}, 
        description="Read a specific item"
    )
```

</td>
<td>

```json
{
  "name": "Foo",
  "id": "item01",
  "link": {
      "href": "/items/item01",
      "method": "GET",
      "description": "Read a specific item"
  }
}
```

</td>
</tr>
</tbody>
</table>

`HALFor` acts as a substitute for `URLFor`. You can place `HALFor` items inside a `LinkSet` and it'll work fine.