### PR TITLE
Handle endpoint as callable on HALFor/UrlFor

### DIFF
--- a/examples/simple_app.py
+++ b/examples/simple_app.py
@@ -2,7 +2,7 @@ from typing import List, Optional
 
 from fastapi import FastAPI
 
-from fastapi_hypermodel import HyperModel, UrlFor, LinkSet
+from fastapi_hypermodel import HyperModel, LinkSet, UrlFor
 
 # Create our FastAPI app
 app = FastAPI()

--- a/fastapi_hypermodel/hypermodel.py
+++ b/fastapi_hypermodel/hypermodel.py
@@ -6,7 +6,7 @@ https://github.com/marshmallow-code/flask-marshmallow/blob/dev/src/flask_marshma
 import abc
 import re
 import urllib
-from typing import Any, Callable, Dict, List, Optional, no_type_check
+from typing import Any, Callable, Dict, List, Optional, Union, no_type_check
 
 from fastapi import FastAPI
 from pydantic import BaseModel, PrivateAttr, root_validator
@@ -42,11 +42,11 @@ class UrlType(str):
 class UrlFor(UrlType, AbstractHyperField):
     def __init__(
         self,
-        endpoint: str,
+        endpoint: Union[Callable, str],
         param_values: Optional[Dict[str, str]] = None,
         condition: Optional[Callable[[Dict[str, Any]], bool]] = None,
     ):
-        self.endpoint: str = endpoint
+        self.endpoint: str = endpoint.__name__ if callable(endpoint) else endpoint
         self.param_values: Dict[str, str] = param_values or {}
         self.condition: Optional[Callable[[Dict[str, Any]], bool]] = condition
         super().__init__()
@@ -98,12 +98,12 @@ class HALFor(HALItem, AbstractHyperField):
 
     def __init__(
         self,
-        endpoint: str,
+        endpoint: Union[Callable, str],
         param_values: Optional[Dict[str, str]] = None,
         description: Optional[str] = None,
         condition: Optional[Callable[[Dict[str, Any]], bool]] = None,
     ):
-        self._endpoint: str = endpoint
+        self._endpoint: str = endpoint.__name__ if callable(endpoint) else endpoint
         self._param_values: Dict[str, str] = param_values or {}
         self._description = description
         self._condition = condition
@@ -253,7 +253,7 @@ class HyperModel(BaseModel):
     @classmethod
     def init_app(cls, app: FastAPI):
         """
-        Bind a FastAPI app to othe HyperModel base class.
+        Bind a FastAPI app to other HyperModel base class.
         This allows HyperModel to convert endpoint function names into
         working URLs relative to the application root.
 

--- a/tests/app.py
+++ b/tests/app.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 from fastapi import FastAPI
 from pydantic.main import BaseModel
 
-from fastapi_hypermodel import HyperModel, UrlFor, LinkSet
+from fastapi_hypermodel import HyperModel, LinkSet, UrlFor
 from fastapi_hypermodel.hypermodel import HALFor
 
 
@@ -99,45 +99,49 @@ people = {
 }
 
 
-def create_app():
-    app = FastAPI()
-    HyperModel.init_app(app)
+test_app = FastAPI()
+HyperModel.init_app(test_app)
 
-    @app.get(
-        "/items",
-        response_model=List[ItemSummary],
-    )
-    def read_items():
-        return list(items.values())
 
-    @app.get("/items/{item_id}", response_model=ItemDetail)
-    def read_item(item_id: str):
-        return items[item_id]
+@test_app.get(
+    "/items",
+    response_model=List[ItemSummary],
+)
+def read_items():
+    return list(items.values())
 
-    @app.put("/items/{item_id}", response_model=ItemDetail)
-    def update_item(item_id: str, item: ItemUpdate):
-        items[item_id].update(item.dict(exclude_none=True))
-        return items[item_id]
 
-    @app.get(
-        "/people",
-        response_model=List[Person],
-    )
-    def read_people():
-        return list(people.values())
+@test_app.get("/items/{item_id}", response_model=ItemDetail)
+def read_item(item_id: str):
+    return items[item_id]
 
-    @app.get("/people/{person_id}", response_model=Person)
-    def read_person(person_id: str):
-        return people[person_id]
 
-    @app.get("/people/{person_id}/items", response_model=List[ItemDetail])
-    def read_person_items(person_id: str):
-        return people[person_id]["items"]
+@test_app.put("/items/{item_id}", response_model=ItemDetail)
+def update_item(item_id: str, item: ItemUpdate):
+    items[item_id].update(item.dict(exclude_none=True))
+    return items[item_id]
 
-    @app.put("/people/{person_id}/items", response_model=List[ItemDetail])
-    def put_person_items(person_id: str, item: ItemCreate):
-        items[item.id] = item.dict()
-        people[person_id]["items"].append(item.dict())
-        return people[person_id]["items"]
 
-    return app
+@test_app.get(
+    "/people",
+    response_model=List[Person],
+)
+def read_people():
+    return list(people.values())
+
+
+@test_app.get("/people/{person_id}", response_model=Person)
+def read_person(person_id: str):
+    return people[person_id]
+
+
+@test_app.get("/people/{person_id}/items", response_model=List[ItemDetail])
+def read_person_items(person_id: str):
+    return people[person_id]["items"]
+
+
+@test_app.put("/people/{person_id}/items", response_model=List[ItemDetail])
+def put_person_items(person_id: str, item: ItemCreate):
+    items[item.id] = item.dict()
+    people[person_id]["items"].append(item.dict())
+    return people[person_id]["items"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,14 @@
 import pytest
 from fastapi.testclient import TestClient
-from .app import create_app
 
 
 @pytest.fixture
 def app():
-    return create_app()
+    from .app import test_app
+
+    return test_app
 
 
 @pytest.fixture
 def client(app):
-    return TestClient(
-        app=app,
-    )
+    return TestClient(app=app)

--- a/tests/test_fastapi_hypermodel.py
+++ b/tests/test_fastapi_hypermodel.py
@@ -1,15 +1,16 @@
 import pytest
 
 from fastapi_hypermodel.hypermodel import (
-    _tpl,
-    _get_value_for_key,
-    _get_value_for_keys,
-    _get_value,
     HyperModel,
     InvalidAttribute,
     UrlFor,
+    _get_value,
+    _get_value_for_key,
+    _get_value_for_keys,
+    _tpl,
 )
-from .app import items, people
+
+from .app import items, people, read_item
 
 
 @pytest.mark.parametrize(
@@ -151,9 +152,16 @@ def test_people_halset_condition_unmet(client, person_id):
     assert "addItem" not in links
 
 
-def test_bad_attribute(app):
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        pytest.param("read_item", id="Use of a string endpoint"),
+        pytest.param(read_item, id="Use of a Callable endpoint"),
+    ],
+)
+def test_bad_attribute(app, endpoint):
     class ItemSummary(HyperModel):
-        href = UrlFor("read_item", {"item_id": "<id>"})
+        href = UrlFor(endpoint, {"item_id": "<id>"})
 
     assert ItemSummary._hypermodel_bound_app is app
 

--- a/tests/test_utility_functions.py
+++ b/tests/test_utility_functions.py
@@ -1,5 +1,6 @@
 import pytest
-from fastapi_hypermodel.hypermodel import resolve_param_values, InvalidAttribute
+
+from fastapi_hypermodel.hypermodel import InvalidAttribute, resolve_param_values
 
 
 def test_resolve_param_values_flat():


### PR DESCRIPTION
## Rationale

The rationale behind this is the ability to refactor the name of an
endpoint without having to grep all HALFor/UrlFor to rename the
endpoint as strings too.

## Example

```py
from app.views import foo_endpoint

class FooResponse(HyperModel):
    links = LinkSet(
        {
             "self": HALFor(foo_endpoint)
        }
    )
```

If I use my IDE[^1] to rename `foo_endpoint()` → `bar_endpoint()`, it will replace all occurrences of its reference in the codebase; without having to search for `"foo_endpoint"` string as well.

I don't know if that makes sense.

> **Note**
> Sorry about the refactoring on `tests/app.py`, but I didn't know any better way to expose a view in tests so I can test the change. Let me know if you have a better idea. 😊 

[^1]: I personally use PyCharm for instance.