### PR TITLE
ci: run ci on a nightly schedule

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,8 @@ on:
   pull_request:
   release:
     types: [published]
+  schedule:
+    - cron: "0 0 * * *"  # every day at midnight
 
 jobs:
   test:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ pytest-lazy-fixtures = ">=1.0.1"
 requests = "^2.25.1"
 ruff = "^0.1.8"
 tox = "^4.4"
-uvicorn = ">=0.17.6,<0.26.0"
+uvicorn = "*"
 
 [build-system]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Used to ensure latest unpinned dependencies don't cause tests to fail, without having to constantly update a Poetry lock file. See https://python-poetry.org/docs/basic-usage/#as-a-library-developer