### PR TITLE
Fix empty sequence adding to embedded bug

### DIFF
--- a/fastapi_hypermodel/hal/hal_hypermodel.py
+++ b/fastapi_hypermodel/hal/hal_hypermodel.py
@@ -220,7 +220,7 @@ class HALHyperModel(HyperModel):
         embedded: Dict[str, Union[Self, Sequence[Self]]] = {}
         for name, field in self:
             value: Sequence[Union[Any, Self]] = (
-                field if isinstance(field, Sequence) else [field]
+                field if isinstance(field, Sequence) and len(field) else [field]
             )
 
             if not all(isinstance(element, HALHyperModel) for element in value):


### PR DESCRIPTION
Implement a check to ensure the sequence length is greater than 0 before adding the field to the embedded dictionary.

For example: if field value is '' then it goes to embedded dict from the model